### PR TITLE
fix: permissions for workflow

### DIFF
--- a/workflow-templates/tag-and-release.yml
+++ b/workflow-templates/tag-and-release.yml
@@ -6,6 +6,8 @@ name: Tag & Release
       - "stackhpc/xena"
       - "stackhpc/wallaby"
       - "stackhpc/victoria"
+permissions:
+  contents: write
 jobs:
   tag-and-release:
     uses: stackhpc/.github/.github/workflows/tag-and-release.yml@main


### PR DESCRIPTION
Some repositories limit their default workflow permissions which prevents the `tag-and-release` workflow from pushing tags. This change overrides this setting.