### PR TITLE
Workflow permissions fix

### DIFF
--- a/workflow-templates/tag-and-release.yml
+++ b/workflow-templates/tag-and-release.yml
@@ -6,6 +6,8 @@ name: Tag & Release
       - "stackhpc/xena"
       - "stackhpc/wallaby"
       - "stackhpc/victoria"
+permissions:
+  contents: write
 jobs:
   tag-and-release:
     uses: stackhpc/.github/.github/workflows/tag-and-release.yml@main

--- a/workflow-templates/upstream-sync.yml
+++ b/workflow-templates/upstream-sync.yml
@@ -4,6 +4,9 @@ name: Upstream Sync
   schedule:
     - cron: "15 8 * * 1"
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   synchronise-xena:
     name: Synchronise stackhpc/xena


### PR DESCRIPTION
Some repositories limit their default workflow permissions which prevents the `tag-and-release` and `upstream-sync` workflows running. This change overrides this setting.