### PR TITLE
fix: setup concurrency for tag-and-release

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -2,6 +2,7 @@
 name: Tag & Release
 'on':
   workflow_call:
+concurrency: ${{ github.repository }}-tag-and-release
 jobs:
   tag:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The `concurrency` setting appears to be working as expected and needed.

This will be prevent multiple workflows attempting to push upstream tags which will result in a data race causing the workflow to fail.

<img width="524" alt="Screenshot 2022-06-15 at 11 44 49" src="https://user-images.githubusercontent.com/52131498/173809781-83a930af-0a31-4a22-9a30-9ef47ae60b80.png">