### PR TITLE
Fix when there is no bindep.txt

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,9 +23,19 @@ jobs:
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install bindep 📦
-          run: pip install bindep
+          run: |
+            if [[ -f bindep.txt ]]; then
+                pip install bindep
+            else
+                echo "No bindep.txt"
+            fi
         - name: Install missing packages 📦
-          run: test -f bindep.txt && sudo apt install $(bindep -b test)
+          run: |
+            if [[ -f bindep.txt ]]; then
+                sudo apt install $(bindep -b test)
+            else
+                echo "No bindep.txt"
+            fi
         - name: Install Tox 📦
           run: pip install tox==3.*
         - name: Run Tox ${{ matrix.environment }} 🧪


### PR DESCRIPTION
Previously, if there was no bindep.txt file, the test command would
return 1, failing the job. bindep.txt is not mandatory, so we shouldn't
fail when it's not present.
