### PR TITLE
Check git tag matches galaxy.yml

### DIFF
--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Assert workflow was triggered on a tag
         run: echo "You must trigger this workflow on a git tag" && exit -1
-        if: github.ref_type != "tag"
+        if: ${{ github.ref_name }} != "tag"
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
       - name: Check git tag matches version in galaxy.yml

--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish Ansible Collection to Ansible Galaxy
     steps:
+      - name: Assert workflow was triggered on a tag
+        run: echo "You must trigger this workflow on a git tag" && exit -1
+        if: github.ref_type != "tag"
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
       - name: Check git tag matches version in galaxy.yml

--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
       - name: Check git tag matches version in galaxy.yml
-        run: git tag --points-at HEAD | grep $(yq -r .version < galaxy.yml)
+        run: echo "${{ github.ref_name }}" | grep $(yq -r .version < galaxy.yml)
       - name: Build Collection 🛠
         run: ansible-galaxy collection build
       - name: Publish Collection 🚀

--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
+      - name: Check git tag matches version in galaxy.yml
+        run: git tag --points-at HEAD | grep $(yq -r .version < galaxy.yml)
       - name: Build Collection 🛠
         run: ansible-galaxy collection build
       - name: Publish Collection 🚀

--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Assert workflow was triggered on a tag
         run: echo "You must trigger this workflow on a git tag" && exit -1
-        if: ${{ github.ref_name != "tag" }}
+        if: github.ref_type != "tag"
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
       - name: Check git tag matches version in galaxy.yml

--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Assert workflow was triggered on a tag
         run: echo "You must trigger this workflow on a git tag" && exit -1
-        if: ${{ github.ref_name }} != "tag"
+        if: ${{ github.ref_name != "tag" }}
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
       - name: Check git tag matches version in galaxy.yml

--- a/.github/workflows/publish-collection.yml
+++ b/.github/workflows/publish-collection.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Assert workflow was triggered on a tag
         run: echo "You must trigger this workflow on a git tag" && exit -1
-        if: github.ref_type != "tag"
+        if: github.ref_type != 'tag'
       - name: Github Checkout 🛎
         uses: actions/checkout@v3
       - name: Check git tag matches version in galaxy.yml


### PR DESCRIPTION
Refuse to publish when version in galaxy.yml doesn't match current git tag. This is to keep versions aligned. It is also possible to use manifest.json instead of galaxy.yml, but I don't we use this in any of our collections.