### PR TITLE
Use full path when running sanity check

### DIFF
--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          # https://github.com/yaml/pyyaml/issues/724
+          pip install "cython<3.0.0"
+          pip install --no-build-isolation pyyaml==5.4.1
           pip install ansible-core==${{ matrix.ansible }}.*
 
       - name: Running sanity tests

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -41,7 +41,11 @@ jobs:
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3
+
+      # Checkout utility scripts
+      - uses: actions/checkout@v3
         with:
+          repository: stackhpc/.github
           path: stackhpc-github
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.10
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -50,13 +50,11 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # https://github.com/yaml/pyyaml/issues/724
-          pip install PyYAML==5.3.1
           pip install ansible-core==${{ matrix.ansible }}.*
 
       - name: Running sanity tests

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -38,7 +38,6 @@ jobs:
         include:
           - ansible: "2.12"
             python: "3.8"
-        include:
           - ansible: "2.14"
             python: "3.11"
 

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -56,8 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # https://github.com/yaml/pyyaml/issues/724
-          pip install "cython<3.0.0"
-          pip install --no-build-isolation pyyaml==5.4.1
+          pip install PyYAML==5.3.1
           pip install ansible-core==${{ matrix.ansible }}.*
 
       - name: Running sanity tests

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3
+        with:
+          path: stackhpc-github
 
       - uses: actions/setup-python@v4
         with:
@@ -53,4 +55,4 @@ jobs:
 
       - name: Running sanity tests
         run: |
-          .github/workflows/collection-sanity.sh
+          $GITHUB_WORKSPACE/stackhpc-github/.github/workflows/collection-sanity.sh

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -35,9 +35,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansible:
-          - "2.12"
-          - "2.14"
+        include:
+          - ansible: "2.12"
+            python: "3.8"
+        include:
+          - ansible: "2.14"
+            python: "3.11"
+
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3
@@ -50,7 +54,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
```
Run .github/workflows/collection-sanity.sh
/home/runner/work/_temp/54a8cac7-3453-49be-a426-1e966f9798bc.sh: line 1: .github/workflows/collection-sanity.sh: No such file or directory
Error: Process completed with exit code 127.
```

See: https://github.com/stackhpc/ansible-collection-linux/actions/runs/5655376499/job/15320367246?pr=10#step:5:12