### PR TITLE
Further fix for linting collection

### DIFF
--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3
+        with:
+          path: repo
 
       # Checkout utility scripts
       - uses: actions/checkout@v3
@@ -63,3 +65,4 @@ jobs:
       - name: Running sanity tests
         run: |
           $GITHUB_WORKSPACE/stackhpc-github/.github/workflows/collection-sanity.sh
+        working-directory: ${{ github.workspace }}/repo


### PR DESCRIPTION
Sorry, missed this one as I thought it was flagging an issue with the repo we were testing:

```
ERROR: Found 3 yamllint issue(s) which need to be resolved:
See documentation for help: https://docs.ansible.com/ansible-core/2.12/dev_guide/testing/sanity/yamllint.html
ERROR: stackhpc-github/.github/workflows/tox.yml:10:30: commas: too few spaces after comma
ERROR: stackhpc-github/.github/workflows/tox.yml:11:36: commas: too few spaces after comma
ERROR: stackhpc-github/.github/workflows/tox.yml:11:38: commas: too few spaces after comma
ERROR: The 1 sanity test(s) listed below (out of 32) failed. See error output above for details.
```