### PR TITLE
lint-collection: Pin Python versions for ansible-lint

### DIFF
--- a/.github/workflows/lint-collection.yml
+++ b/.github/workflows/lint-collection.yml
@@ -15,21 +15,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansible:
-          - "2.12"
-          - "2.14"
+        include:
+          - ansible: "2.12"
+            # ansible-lint 6+ is not supported on Python 3.8.
+            ansible-lint: "5"
+            python: "3.8"
+          - ansible: "2.14"
+            ansible-lint: "6"
+            python: "3.11"
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE, so it's accessible to the job
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ansible-core==${{ matrix.ansible }}.* 'ansible-lint==6.*' ${{ inputs.lint_pip_dependencies }}
+          pip install ansible-core==${{ matrix.ansible }}.* ansible-lint==${{ matrix.ansible-lint }}.* ${{ inputs.lint_pip_dependencies }}
 
       - name: Linting code
         run: |


### PR DESCRIPTION
The ansible-lint job with ansible 2.12 fails to install when using the
latest Python version 3.12:

  AttributeError: '_AnsiblePathHookFinder' object has no attribute 'find_spec'

Pin Python to the same versions used in the ansible sanity jobs.
