### PR TITLE
Update tox matching for Bobcat and caracal

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,11 @@ jobs:
                  (github.base_ref == 'stackhpc/zed') ||
                  (github.ref == 'refs/heads/stackhpc/zed') ||
                  (github.base_ref == 'stackhpc/2023.1') ||
-                 (github.ref == 'refs/heads/stackhpc/2023.1')
+                 (github.ref == 'refs/heads/stackhpc/2023.1') ||
+                 (github.base_ref == 'stackhpc/2023.2') ||
+                 (github.ref == 'refs/heads/stackhpc/2023.2') ||
+                 (github.base_ref == 'stackhpc/2024.1') ||
+                 (github.ref == 'refs/heads/stackhpc/2024.1')
                }}
           exclude:
             - environment: pep8


### PR DESCRIPTION
We only need Caracal for now, but I've added matching for Bobcat as well in case we need to build those branches in the future.