### PR TITLE
Disable fail-fast for tox jobs

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,6 +6,7 @@ jobs:
   tox:
       runs-on: ubuntu-20.04
       strategy:
+        fail-fast: false
         matrix:
           environment: [pep8,py3]
           python-minor-version: [6,8,10]


### PR DESCRIPTION
This ensures that all tox jobs run to completion, even if one fails.
This allows us to see all failures.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
