### PR TITLE
Remove kayobe repo condition to work with other repos

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,9 +28,8 @@ jobs:
           is-not-python38:
             - ${{
                   ((github.repository == 'stackhpc/kayobe') &&
-                  (github.base_ref == 'stackhpc/2024.1')) ||
-                  ((github.repository == 'stackhpc/kayobe') &&
-                  (github.ref == 'refs/heads/stackhpc/2024.1')) ||
+                  ((github.base_ref == 'stackhpc/2024.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2024.1'))) ||
                   (github.base_ref == 'stackhpc/2025.1') ||
                   (github.ref == 'refs/heads/stackhpc/2025.1') ||
                   (github.base_ref == 'stackhpc/master') ||

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,21 +27,21 @@ jobs:
                 }}
           is-not-python38:
             - ${{
-                  (github.repository == 'stackhpc/kayobe') &&
-                  ((github.base_ref == 'stackhpc/2024.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2024.1') ||
+                  ((github.repository == 'stackhpc/kayobe') &&
+                  (github.base_ref == 'stackhpc/2024.1')) ||
+                  ((github.repository == 'stackhpc/kayobe') &&
+                  (github.ref == 'refs/heads/stackhpc/2024.1')) ||
                   (github.base_ref == 'stackhpc/2025.1') ||
                   (github.ref == 'refs/heads/stackhpc/2025.1') ||
                   (github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master'))
+                  (github.ref == 'refs/heads/stackhpc/master')
                 }}
           is-primarily-python312:
             - ${{
-                  (github.repository == 'stackhpc/kayobe') &&
-                  ((github.base_ref == 'stackhpc/2025.1') ||
+                  (github.base_ref == 'stackhpc/2025.1') ||
                   (github.ref == 'refs/heads/stackhpc/2025.1') ||
                   (github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master'))
+                  (github.ref == 'refs/heads/stackhpc/master')
                 }}
           exclude:
             - environment: pep8


### PR DESCRIPTION
The ``github.repository == 'stackhpc/kayobe'`` condition is preventing matrix variables ``is-not-python38`` and ``is-primarily-python312`` to be true for appropriate branches for other repositories.

Removing the condition to fix that.