### PR TITLE
DNM: Stop using ubuntu focal runners

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -9,7 +9,7 @@ name: Tag & Release
         required: false
 jobs:
   turnstyle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Serialise runs of this workflow
     permissions:
       actions: read
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       naming-things-is-hard-repository: stackhpc/naming-things-is-hard
     name: Automatic tagging for ${{ github.ref_name }} 🏷
@@ -59,7 +59,7 @@ jobs:
         run: naming-things-is-hard/os-downstream-tag.py --release $(basename $(git rev-parse --abbrev-ref HEAD))
   release:
     needs: [tag]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Release newly generated tag 🏷
     steps:
       - name: Github checkout 🛎 [${{ github.repository }}]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,22 +9,7 @@ jobs:
         fail-fast: false
         matrix:
           environment: [pep8,py3]
-          python-minor-version: [6,8,10,12]
-          is-not-python36:
-            - ${{
-                  (github.base_ref == 'stackhpc/zed') ||
-                  (github.ref == 'refs/heads/stackhpc/zed') ||
-                  (github.base_ref == 'stackhpc/2023.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2023.1') ||
-                  (github.base_ref == 'stackhpc/2023.2') ||
-                  (github.ref == 'refs/heads/stackhpc/2023.2') ||
-                  (github.base_ref == 'stackhpc/2024.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2024.1') ||
-                  (github.base_ref == 'stackhpc/2025.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
-                  (github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master')
-                }}
+          python-minor-version: [8,10,12]
           is-not-python38:
             - ${{
                   ((github.repository == 'stackhpc/kayobe') &&
@@ -43,15 +28,6 @@ jobs:
                   (github.ref == 'refs/heads/stackhpc/master')
                 }}
           exclude:
-            - environment: pep8
-              python-minor-version: 6
-            - is-not-python36: true
-              python-minor-version: 6
-            - is-not-python36: true
-              environment: pep8
-              python-minor-version: 8
-            - is-not-python36: false
-              python-minor-version: 10
             - is-not-python38: true
               python-minor-version: 8
             - is-primarily-python312: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ name: Tox Workflow
   workflow_call:
 jobs:
   tox:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       strategy:
         fail-fast: false
         matrix:


### PR DESCRIPTION
Ubuntu focal runners support will be removed soon.

We need to either migrate away to Jammy, Noble, or latest and drop python 3.6 support, or move to self-hosted Focal runners.

This PR is up for discussion only, it currently [does not work](https://github.com/stackhpc/kayobe/actions/runs/13281021279/job/37079232116?pr=386) 