### PR TITLE
Refactor tox workflow, remove Python 3.6, and switch to Ubuntu latest runners

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -9,7 +9,7 @@ name: Tag & Release
         required: false
 jobs:
   turnstyle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Serialise runs of this workflow
     permissions:
       actions: read
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       naming-things-is-hard-repository: stackhpc/naming-things-is-hard
     name: Automatic tagging for ${{ github.ref_name }} 🏷
@@ -59,7 +59,7 @@ jobs:
         run: naming-things-is-hard/os-downstream-tag.py --release $(basename $(git rev-parse --abbrev-ref HEAD))
   release:
     needs: [tag]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Release newly generated tag 🏷
     steps:
       - name: Github checkout 🛎 [${{ github.repository }}]

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,22 +9,7 @@ jobs:
         fail-fast: false
         matrix:
           environment: [pep8,py3]
-          python-minor-version: [6,8,10,12]
-          is-not-python36:
-            - ${{
-                  (github.base_ref == 'stackhpc/zed') ||
-                  (github.ref == 'refs/heads/stackhpc/zed') ||
-                  (github.base_ref == 'stackhpc/2023.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2023.1') ||
-                  (github.base_ref == 'stackhpc/2023.2') ||
-                  (github.ref == 'refs/heads/stackhpc/2023.2') ||
-                  (github.base_ref == 'stackhpc/2024.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2024.1') ||
-                  (github.base_ref == 'stackhpc/2025.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
-                  (github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master')
-                }}
+          python-minor-version: [8,10,12]
           is-not-python38:
             - ${{
                   ((github.repository == 'stackhpc/kayobe') &&
@@ -43,15 +28,6 @@ jobs:
                   (github.ref == 'refs/heads/stackhpc/master')
                 }}
           exclude:
-            - environment: pep8
-              python-minor-version: 6
-            - is-not-python36: true
-              python-minor-version: 6
-            - is-not-python36: true
-              environment: pep8
-              python-minor-version: 8
-            - is-not-python36: false
-              python-minor-version: 10
             - is-not-python38: true
               python-minor-version: 8
             - is-primarily-python312: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ name: Tox Workflow
   workflow_call:
 jobs:
   tox:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,38 +3,95 @@ name: Tox Workflow
 'on':
   workflow_call:
 jobs:
+
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      tox-matrix: ${{ steps.matrix.outputs.tox-matrix }}
+    steps:
+      - name: Define Tox matrix
+        id: matrix
+        env:
+          PY3_8: ${{
+                  (github.base_ref == 'stackhpc/yoga') ||
+                  (github.ref == 'refs/heads/stackhpc/yoga') ||
+                  (github.base_ref == 'stackhpc/zed') ||
+                  (github.ref == 'refs/heads/stackhpc/zed') ||
+                  (github.base_ref == 'stackhpc/2023.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2023.1') ||
+                  (((github.base_ref == 'stackhpc/2024.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2024.1')) &&
+                  (github.repository != 'stackhpc/kayobe'))
+                  }}
+          PY3_10: ${{
+                  (github.base_ref == 'stackhpc/zed') ||
+                  (github.ref == 'refs/heads/stackhpc/zed') ||
+                  (github.base_ref == 'stackhpc/2023.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2023.1') ||
+                  (github.base_ref == 'stackhpc/2024.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2024.1') ||
+                  (github.base_ref == 'stackhpc/2025.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
+                  (github.base_ref == 'stackhpc/master') ||
+                  (github.ref == 'refs/heads/stackhpc/master')
+                  }}
+          PY3_12: ${{
+                  (github.base_ref == 'stackhpc/2025.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
+                  (github.base_ref == 'stackhpc/master') ||
+                  (github.ref == 'refs/heads/stackhpc/master')
+                  }}
+          PEP8_8: ${{
+                  (github.base_ref == 'stackhpc/yoga') ||
+                  (github.ref == 'refs/heads/stackhpc/yoga')
+                  }}
+          PEP8_10: ${{
+                  (github.base_ref == 'stackhpc/zed') ||
+                  (github.ref == 'refs/heads/stackhpc/zed') ||
+                  (github.base_ref == 'stackhpc/2023.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2023.1') ||
+                  (github.base_ref == 'stackhpc/2024.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2024.1')
+                  }}
+          PEP8_12: ${{
+                  (github.base_ref == 'stackhpc/2025.1') ||
+                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
+                  (github.base_ref == 'stackhpc/master') ||
+                  (github.ref == 'refs/heads/stackhpc/master')
+                  }}
+        run: |
+          # Create a matrix based on the environment and Python minor version
+          output="["
+          if [[ $PY3_8 == 'true' ]]; then
+              output+="{'environment': 'py3', 'python-minor-version': 8},"
+          fi
+          if [[ $PY3_10 == 'true' ]]; then
+              output+="{'environment': 'py3', 'python-minor-version': 10},"
+          fi
+          if [[ $PY3_12 == 'true' ]]; then
+              output+="{'environment': 'py3', 'python-minor-version': 12},"
+          fi
+          if [[ $PEP8_8 == 'true' ]]; then
+              output+="{'environment': 'pep8', 'python-minor-version': 8},"
+          fi
+          if [[ $PEP8_10 == 'true' ]]; then
+              output+="{'environment': 'pep8', 'python-minor-version': 10},"
+          fi
+          if [[ $PEP8_12 == 'true' ]]; then
+              output+="{'environment': 'pep8', 'python-minor-version': 12},"
+          fi
+          # remove trailing comma
+          output="${output%,}"
+          output+="]"
+          echo "tox-matrix=$output" >> $GITHUB_OUTPUT
+         
   tox:
       runs-on: ubuntu-latest
+      needs: define-matrix
       strategy:
         fail-fast: false
         matrix:
-          environment: [pep8,py3]
-          python-minor-version: [8,10,12]
-          is-not-python38:
-            - ${{
-                  ((github.repository == 'stackhpc/kayobe') &&
-                  ((github.base_ref == 'stackhpc/2024.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2024.1'))) ||
-                  (github.base_ref == 'stackhpc/2025.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
-                  (github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master')
-                }}
-          is-primarily-python312:
-            - ${{
-                  (github.base_ref == 'stackhpc/2025.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
-                  (github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master')
-                }}
-          exclude:
-            - is-not-python38: true
-              python-minor-version: 8
-            - is-primarily-python312: true
-              environment: pep8
-              python-minor-version: 10
-            - is-primarily-python312: false
-              python-minor-version: 12
+          include: ${{ fromJSON(needs.define-matrix.outputs.tox-matrix) }}
 
       name: Tox ${{ matrix.environment }} with Python 3.${{ matrix.python-minor-version }}
       steps:


### PR DESCRIPTION
Ubuntu Focal runners are being removed in two weeks. This makes it impossible to test Python 3.6 without self-hosted runners. 

I've taken the opportunity to remove the terrible tox.yml matrix and build something more readable. The matrix is now built using a separate step, which uses a simple bash script to put together a list of tests. Conditions are evaluated as environment variables before the step starts