### PR TITLE
Allow no license in tag-and-release

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -83,8 +83,14 @@ jobs:
             exit 1
           else
             echo "Creating release for $TAG_NAME"
-            gh release create "$TAG_NAME" \
+            if [[ -f LICENSE ]]; then
+              gh release create "$TAG_NAME" \
               --title "$TAG_NAME" \
               --notes-file changelog.txt \
               LICENSE
+            else
+              gh release create "$TAG_NAME" \
+              --title "$TAG_NAME" \
+              --notes-file changelog.txt
+            fi
           fi


### PR DESCRIPTION
LICENSE file does not always exist. Currently the workflow will fail in this case https://github.com/stackhpc/requirements/actions/runs/25659473100/job/75316133732#step:5:21