### PR TITLE
Drop Python 3.10 tests for stackhpc/master branch

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,11 +32,7 @@ jobs:
                   (github.base_ref == 'stackhpc/2024.1') ||
                   (github.ref == 'refs/heads/stackhpc/2024.1') ||
                   (github.base_ref == 'stackhpc/2025.1') ||
-                  (github.ref == 'refs/heads/stackhpc/2025.1') ||
-                  (((github.base_ref == 'stackhpc/master') ||
-                  (github.ref == 'refs/heads/stackhpc/master')) &&
-                  (github.repository != 'stackhpc/kayobe') &&
-                  (github.repository != 'stackhpc/kolla-ansible'))
+                  (github.ref == 'refs/heads/stackhpc/2025.1')
                   }}
           PY3_12: ${{
                   (github.base_ref == 'stackhpc/2025.1') ||


### PR DESCRIPTION
This should fix failing unit tests in our Magnum fork: https://github.com/stackhpc/magnum/actions/runs/25659266225/job/75315386189